### PR TITLE
add undefined DecodeError class

### DIFF
--- a/lib/ruby_jwt.rb
+++ b/lib/ruby_jwt.rb
@@ -6,6 +6,7 @@ module JWT
 
 	class VerificationError < StandardError;end
 	class SignError < StandardError;end
+	class DecodeError < StandardError;end
 	class DecodeResponse
 		attr_accessor :header, :payload, :signature, :sign_input
 		def initialize(header,payload,signature,sign_input)


### PR DESCRIPTION
Line 152 in ruby_jwt.rb raises a DecodeError which was undefined. This patch set adds the DecodeError.
